### PR TITLE
Use the new tolerant mode flag in Mvel3ToJavaParserVisitor

### DIFF
--- a/.github/workflows/mvel-lsp-pr.yml
+++ b/.github/workflows/mvel-lsp-pr.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         java-version: [17]
-        maven-version: ['3.8.6']
+        maven-version: ['3.9.12']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven
@@ -40,6 +40,17 @@ jobs:
         uses: stCarolas/setup-maven@v5
         with:
           maven-version: ${{ matrix.maven-version }}
+
+      - name: Checkout mvel/mvel main branch
+        uses: actions/checkout@v6
+        with:
+          repository: mvel/mvel
+          ref: main
+          path: mvel
+
+      - name: Build mvel/mvel main branch
+        run: mvn -B clean install -DskipTests
+        working-directory: ./mvel
 
       - name: Build with Maven
         run: mvn -B clean install

--- a/mvel3-completion/src/main/java/org/mvel3/completion/Mvel3CompletionHelper.java
+++ b/mvel3-completion/src/main/java/org/mvel3/completion/Mvel3CompletionHelper.java
@@ -1,14 +1,5 @@
 package org.mvel3.completion;
 
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.github.javaparser.ast.AccessSpecifier;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
@@ -34,9 +25,18 @@ import org.eclipse.lsp4j.Position;
 import org.mvel3.parser.antlr4.Mvel3Lexer;
 import org.mvel3.parser.antlr4.Mvel3Parser;
 import org.mvel3.parser.antlr4.Mvel3ParserBaseVisitor;
-import org.mvel3.parser.antlr4.TolerantMvel3ToJavaParserVisitor;
+import org.mvel3.parser.antlr4.Mvel3ToJavaParserVisitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class Mvel3CompletionHelper {
 
@@ -192,7 +192,7 @@ public class Mvel3CompletionHelper {
             // Let's assume the user is typing a method or field access
             int scopeTokenIndex = previousTokenIndex - 1;
 
-            TolerantMvel3ToJavaParserVisitor visitor = new TolerantMvel3ToJavaParserVisitor();
+            Mvel3ToJavaParserVisitor visitor = new Mvel3ToJavaParserVisitor(true);
             CompilationUnit compilationUnit = (CompilationUnit) visitor.visit(parseTree);
 
             // We can adjust the paths for the vscode project where the user is working (e.g. dependencies by pom.xml)

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
-        <version.org.mvel3>3.0.0-alpha1</version.org.mvel3>
+        <version.org.mvel3>3.0.0-SNAPSHOT</version.org.mvel3>
         <version.org.antlr4>4.10.1</version.org.antlr4>
         <version.org.eclipse.lsp4j>0.24.0</version.org.eclipse.lsp4j>
         <version.antlr4-c3>1.1</version.antlr4-c3>


### PR DESCRIPTION
This PR: 
- Aligns with changes in mvel https://github.com/mvel/mvel/pull/410
- Changes mvel version to 3.0.0-SNAPSHOT, so the main branch is always aligned with the latest changes from mvel main branch. There is a new with-mvel-3.0.0-alpha1 tag created if anyone needs the original code with the alpha1 mvel. 
- Modifies the PR checks, so they build mvel/mvel main branch first. 
- Updates the Maven version in PR checks to 3.9.12. 