### PR TITLE
Update default Java to 21 and Node to the latest LTS 24.

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:
-          maven-version: '3.8.6'
+          maven-version: '3.9.12'
 
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots -ntp install
@@ -34,7 +34,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: 'npm'
           cache-dependency-path: client/package-lock.json
 

--- a/.github/workflows/mvel-lsp-pr.yml
+++ b/.github/workflows/mvel-lsp-pr.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        java-version: [17]
+        java-version: [17, 21]
         maven-version: ['3.9.12']
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -58,7 +58,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: 'npm'
           cache-dependency-path: client/package-lock.json
 

--- a/.github/workflows/mvel-lsp-pr.yml
+++ b/.github/workflows/mvel-lsp-pr.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   mvel-lsp-build:
     concurrency:
-      group: mvel-lsp-${{ matrix.os }}_pr-${{ github.head_ref }}
+      group: mven-lsp-${{ matrix.os }}-${{ matrix.java-version }}-${{ github.head_ref }}
       cancel-in-progress: true
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,14 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:
-          maven-version: '3.8.6'
+          maven-version: '3.9.12'
 
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots install
@@ -35,7 +35,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: 'npm'
           cache-dependency-path: client/package-lock.json
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.release>17</maven.compiler.release>
         <version.org.mvel3>3.0.0-SNAPSHOT</version.org.mvel3>
         <version.org.antlr4>4.10.1</version.org.antlr4>
         <version.org.eclipse.lsp4j>0.24.0</version.org.eclipse.lsp4j>


### PR DESCRIPTION
Updates GitHub Action workflows to default to Java 21, Maven 3.9.12 and Node 24.x. The code still targets Java 17 for compatibility and a Java 17 PR check is added. 